### PR TITLE
feat: use XDG config path with legacy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ The **pace indicator** (`1.3x`) shows how fast you're consuming your limit compa
 
 ## Configuration
 
-Create `~/.claude-statusline.conf`:
+Create `~/.config/claude-statusline/config`:
 
 ```bash
+mkdir -p ~/.config/claude-statusline
+cat > ~/.config/claude-statusline/config << 'EOF'
 # ─────────────────────────────────────────────────────────
 # Context Warning Threshold
 # ─────────────────────────────────────────────────────────
@@ -126,6 +128,7 @@ RATE_CACHE_TTL=15
 # 7 = All days (if you work weekends)
 # Range: 1-7, Default: 5
 WORK_DAYS_PER_WEEK=5
+EOF
 ```
 
 ---

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -141,18 +141,26 @@ fi
 input=$(cat)
 
 # === User Configuration ===
-# Config file: ~/.claude-statusline.conf
+# Config file locations (in order of priority):
+#   1. $XDG_CONFIG_HOME/claude-statusline/config (or ~/.config/claude-statusline/config)
+#   2. ~/.claude-statusline.conf (legacy fallback)
 # Example content:
 #   CONTEXT_WARNING_THRESHOLD=75
 #   RATE_CACHE_TTL=30
 #   WORK_DAYS_PER_WEEK=5
 #
-CONFIG_FILE="$HOME/.claude-statusline.conf"
+XDG_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claude-statusline"
+CONFIG_FILE=""
+if [ -f "$XDG_CONFIG_DIR/config" ]; then
+    CONFIG_FILE="$XDG_CONFIG_DIR/config"
+elif [ -f "$HOME/.claude-statusline.conf" ]; then
+    CONFIG_FILE="$HOME/.claude-statusline.conf"
+fi
 CONTEXT_WARNING_THRESHOLD=""  # Empty = disabled (uses default color scheme)
 RATE_CACHE_TTL=15             # Seconds between API refreshes (10-120)
 WORK_DAYS_PER_WEEK=5          # 5 = Mon-Fri, 7 = all days (for 7d pace calculation)
 
-if [ -f "$CONFIG_FILE" ]; then
+if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
     # Source config file (only specific variables for security)
     while IFS='=' read -r key value; do
         key=$(echo "$key" | tr -d '[:space:]')


### PR DESCRIPTION
Dotfiles directly in ~ clutter the home directory. XDG Base Directory
spec solves this by centralizing config in ~/.config/. Many macOS CLI
tools also follow XDG now. Falls back to ~/.claude-statusline.conf for
existing users.