### PR TITLE
feat: cost-normalized burn rate and pace (v4.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.1.0] - 2026-02-20
+
+### Added
+- **Cost-normalized burn rate and pace** — Values adjusted by model cost tier
+  - Opus: 5x multiplier (burns budget faster)
+  - Sonnet: 1x baseline (no change)
+  - Haiku: 0.25x multiplier (burns budget slower)
+  - Non-baseline models show "≈" prefix on normalized values
+  - Applied to: burn rate (t/m), cost/hour, 5h pace, 7d pace
+- **Config support** for cost normalization weights:
+  - `COST_NORMALIZE=true|false` (default: true)
+  - `COST_WEIGHT_OPUS=5.0`, `COST_WEIGHT_SONNET=1.0`, `COST_WEIGHT_HAIKU=0.25`
+
 ## [4.0.0] - 2026-02-12
 
 ### Added

--- a/adapter/config/config.go
+++ b/adapter/config/config.go
@@ -86,8 +86,27 @@ func parseFile(path string, cfg *types.Config) bool {
 			if n, err := strconv.Atoi(value); err == nil && n >= 1 && n <= 7 {
 				cfg.WorkDaysPerWeek = n
 			}
+		case "COST_NORMALIZE":
+			cfg.CostNormalize = parseBool(value)
+		case "COST_WEIGHT_OPUS":
+			if f, err := strconv.ParseFloat(value, 64); err == nil && f > 0 {
+				cfg.CostWeightOpus = f
+			}
+		case "COST_WEIGHT_SONNET":
+			if f, err := strconv.ParseFloat(value, 64); err == nil && f > 0 {
+				cfg.CostWeightSonnet = f
+			}
+		case "COST_WEIGHT_HAIKU":
+			if f, err := strconv.ParseFloat(value, 64); err == nil && f > 0 {
+				cfg.CostWeightHaiku = f
+			}
 		}
 	}
 
 	return true
+}
+
+func parseBool(s string) bool {
+	lower := strings.ToLower(s)
+	return lower == "true" || lower == "1" || lower == "yes"
 }

--- a/adapter/config/config_test.go
+++ b/adapter/config/config_test.go
@@ -84,3 +84,88 @@ WORK_DAYS_PER_WEEK=3
 		t.Errorf("WorkDaysPerWeek = %d, want 3", cfg.WorkDaysPerWeek)
 	}
 }
+
+func TestParseCostNormalizeSettings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	os.WriteFile(path, []byte(`
+COST_NORMALIZE=true
+COST_WEIGHT_OPUS=10.0
+COST_WEIGHT_SONNET=1.0
+COST_WEIGHT_HAIKU=0.5
+`), 0o644)
+
+	cfg := types.DefaultConfig()
+	cfg.CostNormalize = false // Override default to test parsing
+	parseFile(path, &cfg)
+
+	if !cfg.CostNormalize {
+		t.Error("CostNormalize should be true")
+	}
+	if cfg.CostWeightOpus != 10.0 {
+		t.Errorf("CostWeightOpus = %f, want 10.0", cfg.CostWeightOpus)
+	}
+	if cfg.CostWeightSonnet != 1.0 {
+		t.Errorf("CostWeightSonnet = %f, want 1.0", cfg.CostWeightSonnet)
+	}
+	if cfg.CostWeightHaiku != 0.5 {
+		t.Errorf("CostWeightHaiku = %f, want 0.5", cfg.CostWeightHaiku)
+	}
+}
+
+func TestParseCostNormalizeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	os.WriteFile(path, []byte(`COST_NORMALIZE=false`), 0o644)
+
+	cfg := types.DefaultConfig() // Default is true
+	parseFile(path, &cfg)
+
+	if cfg.CostNormalize {
+		t.Error("CostNormalize should be false when set to 'false'")
+	}
+}
+
+func TestParseCostWeightInvalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	os.WriteFile(path, []byte(`
+COST_WEIGHT_OPUS=0
+COST_WEIGHT_HAIKU=-1
+`), 0o644)
+
+	cfg := types.DefaultConfig()
+	parseFile(path, &cfg)
+
+	// Invalid values should keep defaults
+	if cfg.CostWeightOpus != 5.0 {
+		t.Errorf("CostWeightOpus = %f, want 5.0 (default)", cfg.CostWeightOpus)
+	}
+	if cfg.CostWeightHaiku != 0.25 {
+		t.Errorf("CostWeightHaiku = %f, want 0.25 (default)", cfg.CostWeightHaiku)
+	}
+}
+
+func TestParseBool(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{"1", true},
+		{"yes", true},
+		{"false", false},
+		{"0", false},
+		{"no", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := parseBool(tt.input)
+		if got != tt.want {
+			t.Errorf("parseBool(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -97,10 +97,10 @@ func main() {
 
 	// 3. Rate limit sections (OAuth) or Cost sections (API key)
 	if creds.HasOAuth() {
-		rate := ratelimit.RenderSections(input, creds, cfg, plat, store, api, rend)
+		rate := ratelimit.RenderSections(input, creds, cfg, plat, store, api, rend, modelInfo.CostTier)
 		sections = append(sections, rate.FiveHour, rate.Burn, rate.SevenDay)
 	} else {
-		cs := cost.RenderSections(input, cfg, plat, store, rend)
+		cs := cost.RenderSections(input, cfg, plat, store, rend, modelInfo.CostTier)
 		sections = append(sections, cs.Session, cs.Daily, cs.Burn)
 	}
 

--- a/core/cost/normalize.go
+++ b/core/cost/normalize.go
@@ -1,0 +1,50 @@
+package cost
+
+import "github.com/Benniphx/claude-statusline/core/types"
+
+// CostMultiplier returns the cost weight for a given model tier.
+func CostMultiplier(tier types.CostTier, cfg types.Config) float64 {
+	switch tier {
+	case types.CostTierOpus:
+		return cfg.CostWeightOpus
+	case types.CostTierHaiku:
+		return cfg.CostWeightHaiku
+	default:
+		return cfg.CostWeightSonnet
+	}
+}
+
+// IsNonBaseline returns true if the tier is not the Sonnet baseline.
+func IsNonBaseline(tier types.CostTier) bool {
+	return tier != types.CostTierSonnet
+}
+
+// NormalizeBurnRate applies cost normalization to a burn rate (tokens/min).
+// Returns the normalized value and whether normalization was applied.
+func NormalizeBurnRate(tpm float64, tier types.CostTier, cfg types.Config) (float64, bool) {
+	if !cfg.CostNormalize {
+		return tpm, false
+	}
+	multiplier := CostMultiplier(tier, cfg)
+	return tpm * multiplier, IsNonBaseline(tier)
+}
+
+// NormalizePace applies cost normalization to a pace value.
+// Returns the normalized value and whether normalization was applied.
+func NormalizePace(pace float64, tier types.CostTier, cfg types.Config) (float64, bool) {
+	if !cfg.CostNormalize {
+		return pace, false
+	}
+	multiplier := CostMultiplier(tier, cfg)
+	return pace * multiplier, IsNonBaseline(tier)
+}
+
+// NormalizeCostPerHour applies cost normalization to cost/hour.
+// Returns the normalized value and whether normalization was applied.
+func NormalizeCostPerHour(cph float64, tier types.CostTier, cfg types.Config) (float64, bool) {
+	if !cfg.CostNormalize {
+		return cph, false
+	}
+	multiplier := CostMultiplier(tier, cfg)
+	return cph * multiplier, IsNonBaseline(tier)
+}

--- a/core/cost/normalize_test.go
+++ b/core/cost/normalize_test.go
@@ -1,0 +1,149 @@
+package cost
+
+import (
+	"testing"
+
+	"github.com/Benniphx/claude-statusline/core/types"
+)
+
+func TestCostMultiplier(t *testing.T) {
+	cfg := types.DefaultConfig()
+
+	tests := []struct {
+		name string
+		tier types.CostTier
+		want float64
+	}{
+		{"opus", types.CostTierOpus, 5.0},
+		{"sonnet", types.CostTierSonnet, 1.0},
+		{"haiku", types.CostTierHaiku, 0.25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CostMultiplier(tt.tier, cfg)
+			if got != tt.want {
+				t.Errorf("CostMultiplier(%v) = %f, want %f", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCostMultiplierCustomWeights(t *testing.T) {
+	cfg := types.DefaultConfig()
+	cfg.CostWeightOpus = 10.0
+	cfg.CostWeightHaiku = 0.5
+
+	if got := CostMultiplier(types.CostTierOpus, cfg); got != 10.0 {
+		t.Errorf("CostMultiplier(opus, custom) = %f, want 10.0", got)
+	}
+	if got := CostMultiplier(types.CostTierHaiku, cfg); got != 0.5 {
+		t.Errorf("CostMultiplier(haiku, custom) = %f, want 0.5", got)
+	}
+}
+
+func TestNormalizeBurnRate(t *testing.T) {
+	cfg := types.DefaultConfig()
+
+	tests := []struct {
+		name     string
+		tpm      float64
+		tier     types.CostTier
+		wantTPM  float64
+		wantNorm bool
+	}{
+		{"sonnet_baseline", 1000, types.CostTierSonnet, 1000, false},
+		{"opus_5x", 1000, types.CostTierOpus, 5000, true},
+		{"haiku_0.25x", 1000, types.CostTierHaiku, 250, true},
+		{"zero_tpm", 0, types.CostTierOpus, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTPM, gotNorm := NormalizeBurnRate(tt.tpm, tt.tier, cfg)
+			if gotTPM != tt.wantTPM {
+				t.Errorf("NormalizeBurnRate tpm = %f, want %f", gotTPM, tt.wantTPM)
+			}
+			if gotNorm != tt.wantNorm {
+				t.Errorf("NormalizeBurnRate normalized = %v, want %v", gotNorm, tt.wantNorm)
+			}
+		})
+	}
+}
+
+func TestNormalizeBurnRateDisabled(t *testing.T) {
+	cfg := types.DefaultConfig()
+	cfg.CostNormalize = false
+
+	// With normalization disabled, Opus should return raw value
+	gotTPM, gotNorm := NormalizeBurnRate(1000, types.CostTierOpus, cfg)
+	if gotTPM != 1000 {
+		t.Errorf("Disabled: tpm = %f, want 1000", gotTPM)
+	}
+	if gotNorm {
+		t.Error("Disabled: normalized should be false")
+	}
+}
+
+func TestNormalizePace(t *testing.T) {
+	cfg := types.DefaultConfig()
+
+	tests := []struct {
+		name     string
+		pace     float64
+		tier     types.CostTier
+		wantPace float64
+		wantNorm bool
+	}{
+		{"sonnet_baseline", 1.0, types.CostTierSonnet, 1.0, false},
+		{"opus_5x", 1.0, types.CostTierOpus, 5.0, true},
+		{"haiku_0.25x", 1.0, types.CostTierHaiku, 0.25, true},
+		{"opus_partial", 0.5, types.CostTierOpus, 2.5, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPace, gotNorm := NormalizePace(tt.pace, tt.tier, cfg)
+			if gotPace != tt.wantPace {
+				t.Errorf("NormalizePace = %f, want %f", gotPace, tt.wantPace)
+			}
+			if gotNorm != tt.wantNorm {
+				t.Errorf("NormalizePace normalized = %v, want %v", gotNorm, tt.wantNorm)
+			}
+		})
+	}
+}
+
+func TestNormalizeCostPerHour(t *testing.T) {
+	cfg := types.DefaultConfig()
+
+	// Opus $2/h → normalized $10/h
+	got, norm := NormalizeCostPerHour(2.0, types.CostTierOpus, cfg)
+	if got != 10.0 {
+		t.Errorf("NormalizeCostPerHour(opus) = %f, want 10.0", got)
+	}
+	if !norm {
+		t.Error("NormalizeCostPerHour(opus) should be normalized")
+	}
+
+	// Sonnet stays the same
+	got2, norm2 := NormalizeCostPerHour(2.0, types.CostTierSonnet, cfg)
+	if got2 != 2.0 {
+		t.Errorf("NormalizeCostPerHour(sonnet) = %f, want 2.0", got2)
+	}
+	if norm2 {
+		t.Error("NormalizeCostPerHour(sonnet) should not be normalized")
+	}
+}
+
+func TestIsNonBaseline(t *testing.T) {
+	if IsNonBaseline(types.CostTierSonnet) {
+		t.Error("Sonnet should be baseline")
+	}
+	if !IsNonBaseline(types.CostTierOpus) {
+		t.Error("Opus should be non-baseline")
+	}
+	if !IsNonBaseline(types.CostTierHaiku) {
+		t.Error("Haiku should be non-baseline")
+	}
+}

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -46,6 +46,10 @@ type Config struct {
 	WorkDaysPerWeek         int           // 1-7, used for 7-day pace scaling
 	CacheDir                string        // Directory for cache files
 	Version                 string        // Current binary version
+	CostNormalize           bool          // Enable cost-normalized burn rate
+	CostWeightOpus          float64       // Cost weight for Opus models (default 5.0)
+	CostWeightSonnet        float64       // Cost weight for Sonnet models (default 1.0, baseline)
+	CostWeightHaiku         float64       // Cost weight for Haiku models (default 0.25)
 }
 
 // DefaultConfig returns configuration with sensible defaults.
@@ -56,6 +60,10 @@ func DefaultConfig() Config {
 		WorkDaysPerWeek:         5,
 		CacheDir:                "/tmp",
 		Version:                 "dev",
+		CostNormalize:           true,
+		CostWeightOpus:          5.0,
+		CostWeightSonnet:        1.0,
+		CostWeightHaiku:         0.25,
 	}
 }
 
@@ -75,7 +83,17 @@ type ModelInfo struct {
 	ShortName      string
 	DefaultContext int
 	IsLocal        bool
+	CostTier       CostTier // Model cost tier for normalization
 }
+
+// CostTier represents the pricing tier of a model.
+type CostTier int
+
+const (
+	CostTierSonnet CostTier = iota // Default/baseline
+	CostTierOpus
+	CostTierHaiku
+)
 
 // ContextDisplay holds computed context window display data.
 type ContextDisplay struct {


### PR DESCRIPTION
## Summary
- Add model cost-normalized burn rate, cost/hour, and pace (5h + 7d)
- Opus=5x, Sonnet=1x (baseline), Haiku=0.25x multipliers
- Non-baseline models show "≈" prefix on normalized values
- Config: `COST_NORMALIZE`, `COST_WEIGHT_OPUS/SONNET/HAIKU`

Jira: https://jobrad.atlassian.net/browse/JRDEX-419

## Test plan
- [x] All existing tests pass (no regressions)
- [x] New tests for normalize functions, model CostTier detection, config parsing
- [x] Rendering tests verify ≈ prefix for Opus, no prefix for Sonnet
- [x] Build compiles successfully