### PR TITLE
docs: Known-issue for api/oauth/usage persistent 429

### DIFF
--- a/adapter/api/oauth_usage_fixture_test.go
+++ b/adapter/api/oauth_usage_fixture_test.go
@@ -1,0 +1,69 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+)
+
+// TestOAuthUsageEndpointLive checks whether the /api/oauth/usage endpoint is
+// currently functional. This is a live integration test — it requires a valid
+// OAuth token in the environment.
+//
+// Run manually to check if the known 429 issue (anthropics/claude-code#30930)
+// has been resolved:
+//
+//	go test ./adapter/api/... -run TestOAuthUsageEndpointLive -v
+//
+// The test is skipped automatically in CI (no CLAUDE_CODE_OAUTH_TOKEN set).
+func TestOAuthUsageEndpointLive(t *testing.T) {
+	token := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")
+	if token == "" {
+		t.Skip("CLAUDE_CODE_OAUTH_TOKEN not set — skipping live test")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.anthropic.com/api/oauth/usage", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("HTTP request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	t.Logf("HTTP %d — body: %v", resp.StatusCode, body)
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		t.Errorf("KNOWN ISSUE STILL ACTIVE: endpoint returns 429 (anthropics/claude-code#30930)\n%s",
+			"See docs/known-issues.md for details and workaround.")
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("unexpected status %d: %v", resp.StatusCode, body)
+		return
+	}
+
+	// Verify expected fields are present
+	for _, field := range []string{"five_hour", "seven_day"} {
+		if _, ok := body[field]; !ok {
+			t.Errorf("response missing field %q — API shape may have changed", field)
+		}
+	}
+
+	fmt.Printf("✅ Endpoint is WORKING — known issue appears to be fixed!\n")
+	fmt.Printf("   five_hour: %v\n", body["five_hour"])
+	fmt.Printf("   seven_day: %v\n", body["seven_day"])
+}

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,54 @@
+# Known Issues
+
+## `api/oauth/usage` returns persistent 429 (since ~Feb 2026)
+
+**Status:** Open — no fix from Anthropic yet
+**Tracking:** [anthropics/claude-code#30930](https://github.com/anthropics/claude-code/issues/30930), [#31021](https://github.com/anthropics/claude-code/issues/31021)
+
+### Symptom
+
+The 5h and 7d utilization percentages in the statusline freeze and stop updating.
+The `/tmp/claude_rate_limit_cache.json` cache file becomes stale (hours or days old).
+
+### Root Cause
+
+`GET https://api.anthropic.com/api/oauth/usage` has a secondary rate limit of approximately
+5 requests per window. Claude Code itself also calls this endpoint (for the built-in `/usage`
+command), which exhausts the limit immediately. Any external tool calling the same endpoint
+then receives HTTP 429 indefinitely.
+
+This is **not a bug in this tool** — it is a server-side rate limit on Anthropic's end.
+
+### How to verify
+
+```bash
+# Check cache age
+stat -f "%Sm" /tmp/claude_rate_limit_cache.json
+
+# Test the endpoint directly
+TOKEN=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('claudeAiOauth',{}).get('accessToken',''))")
+curl -s "https://api.anthropic.com/api/oauth/usage" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "anthropic-beta: oauth-2025-04-20"
+# Returns: {"error":{"type":"rate_limit_error","message":"Rate limited. Please try again later."}}
+```
+
+### Current behavior
+
+No workaround available. The last successfully fetched values remain visible (stale).
+A TTL increase would not help — Claude Code itself exhausts the rate limit regardless of how often this tool calls the endpoint.
+
+### Fix eta
+
+Unknown. The correct long-term fix is for Anthropic to expose rate limit utilization data
+in the statusLine stdin JSON (tracked in [anthropics/claude-code#27829](https://github.com/anthropics/claude-code/issues/27829)
+and [#29604](https://github.com/anthropics/claude-code/issues/29604)).
+
+### How to check if the issue is fixed
+
+Run `make test-oauth-usage` or:
+
+```bash
+go test ./adapter/api/... -run TestOAuthUsageEndpointLive -v
+```


### PR DESCRIPTION
The `api/oauth/usage` endpoint returns HTTP 429 persistently since ~Feb 2026.

- Adds `docs/known-issues.md` with root cause and verify steps
- Adds live fixture test `adapter/api/oauth_usage_fixture_test.go` to detect when fixed

No code changes — documentation only.

Upstream: https://github.com/anthropics/claude-code/issues/30930