### PR TITLE
fix(platform): skip OAuth in proxy mode

### DIFF
--- a/adapter/platform/platform_darwin.go
+++ b/adapter/platform/platform_darwin.go
@@ -15,7 +15,15 @@ import (
 
 // GetCredentials retrieves OAuth credentials on macOS.
 // Priority: env var → keychain → error.
+// When ANTHROPIC_BASE_URL points to a non-Anthropic proxy (e.g. LiteLLM gateway),
+// OAuth rate limits are not applicable — skip OAuth to show cost metrics instead.
 func (p *Platform) GetCredentials() (types.Credentials, error) {
+	// 0. Proxy mode: skip OAuth when routed through a non-Anthropic gateway
+	if base := os.Getenv("ANTHROPIC_BASE_URL"); base != "" &&
+		!strings.Contains(base, "anthropic.com") {
+		return types.Credentials{}, fmt.Errorf("proxy mode: OAuth rate limits not applicable")
+	}
+
 	// 1. Environment variable
 	if token := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); token != "" {
 		return types.Credentials{OAuthToken: token}, nil

--- a/adapter/platform/platform_linux.go
+++ b/adapter/platform/platform_linux.go
@@ -16,7 +16,15 @@ import (
 
 // GetCredentials retrieves OAuth credentials on Linux.
 // Priority: env var → credentials file → error.
+// When ANTHROPIC_BASE_URL points to a non-Anthropic proxy (e.g. LiteLLM gateway),
+// OAuth rate limits are not applicable — skip OAuth to show cost metrics instead.
 func (p *Platform) GetCredentials() (types.Credentials, error) {
+	// 0. Proxy mode: skip OAuth when routed through a non-Anthropic gateway
+	if base := os.Getenv("ANTHROPIC_BASE_URL"); base != "" &&
+		!strings.Contains(base, "anthropic.com") {
+		return types.Credentials{}, fmt.Errorf("proxy mode: OAuth rate limits not applicable")
+	}
+
 	// 1. Environment variable
 	if token := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); token != "" {
 		return types.Credentials{OAuthToken: token}, nil


### PR DESCRIPTION
When `ANTHROPIC_BASE_URL` points to a non-Anthropic gateway (e.g. LiteLLM), OAuth rate limits don't apply. Previously the statusbar showed 5h/7d rate limit windows instead of cost metrics in proxy mode.

- Skip OAuth lookup when `ANTHROPIC_BASE_URL` is set and doesn't contain `anthropic.com`
- Falls through to cost mode (`HasOAuth() = false`)
- Fixes display when using `claude-jobrad` wrapper alongside a regular Claude subscription